### PR TITLE
adapt to SuperTokenV1Library changes

### DIFF
--- a/docs/protocol/distributions/examples/example1.mdx
+++ b/docs/protocol/distributions/examples/example1.mdx
@@ -75,13 +75,7 @@ The `AdSpotContract` is initialized with necessary Superfluid interfaces and par
 
 ```solidity
 constructor(ISuperToken _acceptedToken)
-    SuperAppBaseFlow(
-        ISuperfluid(ISuperToken(_acceptedToken).getHost()),
-        true,
-        true,
-        true,
-        string("")
-    )
+    CFASuperAppBase(ISuperfluid(_acceptedToken.getHost()))
 {
     // Contract initialization code
 }

--- a/docs/protocol/distributions/guides/on-chain.mdx
+++ b/docs/protocol/distributions/guides/on-chain.mdx
@@ -36,26 +36,30 @@ The same pool can be used to distribute any Super Token, be it for Instant or St
 ### createPool
 
 ```solidity
-function createPool(contract ISuperToken token,address admin,struct PoolConfig poolConfig) internal returns (contract ISuperfluidPool pool)
+function createPool(ISuperToken token, address admin, struct PoolConfig poolConfig) internal returns (contract ISuperfluidPool pool)
+
+// simplified variant using the following default settings:
+// admin = msg.sender, poolConfig = { transferabilityForUnitsOwner: false, distributionFromAnyAddress: true }
+function createPool(contract ISuperToken token) internal returns (contract ISuperfluidPool pool);
 ```
 
 Creates a new Superfluid Distribution Pool.
 
-### updateMemberUnits
+### distribute
 
 ```solidity
-function updateMemberUnits( contract ISuperToken token, contract ISuperfluidPool pool, address memberAddress, uint128 newUnits) internal returns (bool)
+function distribute(ISuperToken token, ISuperfluidPool pool, uint256 amount) internal returns (bool)
 ```
 
-Updates the units of a pool member.
+Distributes the specified amount of tokens among pool members.
 
 ### distributeFlow
 
 ```solidity
-function distributeFlow(ISuperToken token, address from, ISuperfluidPool pool, int96 requestedFlowRate) internal returns (bool)
+function distributeFlow(ISuperToken token, ISuperfluidPool pool, int96 requestedFlowRate) internal returns (bool)
 ```
 
-Initiates a distribution flow from a sender to a pool with the specified flow rate.
+Initiates a distribution flow from a sender to a pool with the specified total flow rate.
 
 :::warning Important
 Keep in mind that the total amount of units in the pool needs to be significantly lower than the total flow rate or the total tokens distributed of the pool.
@@ -65,7 +69,7 @@ To understand more why this is the case, please refer to the [Member Units](/doc
 ### connectPool
 
 ```solidity
-function connectPool( contract ISuperToken token, contract ISuperfluidPool pool) internal returns (bool)
+function connectPool(ISuperToken token, contract ISuperfluidPool pool) internal returns (bool)
 ```
 
 Connects a pool member to pool.
@@ -89,6 +93,16 @@ function isMemberConnected(ISuperToken token, address pool, address member) inte
 ```
 
 Checks whether a member is connected to a pool and eligible to receive distributions.
+
+## ISuperfluidPool
+
+### updateMemberUnits
+
+```solidity
+function updateMemberUnits(address memberAddress, uint128 newUnits) internal returns (bool)
+```
+
+Updates the units of a pool member.
 
 ## Contract Example
 
@@ -115,7 +129,7 @@ contract MyDistributionsContract {
     }
 
     function startStreamingDistribution(ISuperfluidPool pool, int96 flowRate) public {
-        _superToken.distributeFlow(address(this), pool, flowRate);
+        _superToken.distributeFlow(pool, flowRate);
         // Additional logic for streaming distribution
     }
 }

--- a/docs/protocol/distributions/guides/pools.mdx
+++ b/docs/protocol/distributions/guides/pools.mdx
@@ -10,7 +10,7 @@ In this page we will explain Distribution Pools and show you the most relevant w
 To do this, we will go through some key concepts, and show you how to leverage Superfluid's [`SuperTokenV1Library.sol`](/docs/technical-reference/SuperTokenV1Library) for your Distribution Pools smart contracts.
 
 :::note About `SuperTokenV1Library.sol`
-The [`SuperTokenV1Library.sol`](/docs/technical-reference/SuperTokenV1Library) is a comprehensive library that enables interactions with all of the Superfluid components (including Pools) through the SuperToken interface.
+The [`SuperTokenV1Library.sol`](/docs/technical-reference/SuperTokenV1Library) is a comprehensive library which makes it more convenient to use invoke Superfluid specific functionality on Super Tokens.
 :::
 
 :::warning About the General Distributions Agreement - GDA
@@ -131,11 +131,10 @@ Members can always disconnect from the pool to stop receiving distributions in r
 
 ## Important Functions
 
-Here are some of the most important functions provided by [`SuperTokenV1Library.sol`](/docs/technical-reference/SuperTokenV1Library) for interacting with Superfluid pools:
+Here are some of the most important functions for interacting with Superfluid pools:
 
 :::note Reminder
-These functions are meant to be called from contracts that import `SuperTokenV1Library.sol`
-and are not directly accessible as external calls on the blockchain.
+Some of this functions are available via [`SuperTokenV1Library.sol`](/docs/technical-reference/SuperTokenV1Library) (contracts using that lib) only.
 :::
 
 ### createPool
@@ -161,10 +160,14 @@ struct PoolConfig {
 We don't recommend setting `transferabilityForUnitsOwner` to `true` unless you have a specific use case that absolutely requires it. This can sometimes lead to unexpected behavior and security risks.
 :::
 
+SuperTokenV1Library also provides overloaded variants setting default values for `admin` (default: `msg.sender`) and/or `poolConfig` (default: `{ transferabilityForUnitsOwner: false, distributionFromAnyAddress: true }`).
+
 ### updateMemberUnits
 
+This function is part of `ISuperfluidPool`, can thus be invoked on pool contracts.
+
 ```solidity
-function updateMemberUnits(ISuperToken token, ISuperfluidPool pool, address memberAddress, uint128 newUnits)
+function updateMemberUnits(address memberAddress, uint128 newUnits)
 ```
 
 Updates the number of units a member has within a pool, effectively changing their share of future distributions.
@@ -204,13 +207,21 @@ function disconnectPool(ISuperToken token, ISuperfluidPool pool)
 
 Disconnects a pool member from a pool.
 
-### distributeToPool
+### distribute
 
 ```solidity
-function distributeToPool(ISuperToken token, address from, ISuperfluidPool pool, uint256 requestedAmount)
+function distribute(ISuperToken token, ISuperfluidPool pool, uint256 requestedAmount)
 ```
 
 Distributes a specified amount of tokens to the pool, to be shared among members according to their units.
+
+### distributeFlow
+
+```solidity
+function distributeFlow(ISuperToken token, ISuperfluidPool pool, int96 requestedFlowRate)
+```
+
+Flow-distributes with the specified flowrate to the pool, with the flow going to members according to their units.
 
 ## Example Usage
 
@@ -221,29 +232,31 @@ Here's how you might use these functions within a smart contract to set up and m
 
 contract MyPool {
     Using SuperTokenV1Library for ISuperToken;
+    
     ISuperToken private superToken;
     ISuperfluidPool private pool;
-    PoolConfig private poolConfig = PoolConfig({
-        transferabilityForUnitsOwner: true,
-        distributionFromAnyAddress: true
-    });
-
+    
     constructor(ISuperToken _superToken) {
         superToken = _superToken;
-        pool = superToken.createPool(address(this), poolConfig);
+        // create a pool with default settings:
+        // msg.sender is admin, non-transferrable units, anybody can distribute to it
+        pool = superToken.createPool();
     }
 
-    // Use updateMemberUnits to assign units to a member
+    // Use updateMemberUnits to assign units to a member.
+    // (This will typically be a permissioned operation, it's akin to minting tokens)
     function updateMemberUnits(address member, uint128 units) public {
-        superToken.updateMemberUnits(pool, member, units);
+        pool.updateMemberUnits(member, units);
     }
 
+    // Instant distribution of tokens to pool members proportional to their current units
     function distribute(uint256 amount) public {
-        superToken.distributeToPool(address(this), pool, amount);
+        superToken.distribute(pool, amount);
     }
 
+    // Flow distribution of tokens to pool members proportional to their current units
     function distributeFlow(int96 flowRate) public {
-        superToken.distributeFlow(address(this), pool, flowRate);
+        superToken.distributeFlow(pool, flowRate);
     }
 }
 ```

--- a/docs/protocol/distributions/guides/testing.mdx
+++ b/docs/protocol/distributions/guides/testing.mdx
@@ -31,7 +31,7 @@ Before diving into testing your Superfluid contracts with Foundry, make sure you
 3. **Installing Superfluid Protocol Dependencies**:
 
    ```bash
-   forge install superfluid-protocol-monorepo=https://github.com/superfluid-finance/protocol-monorepo@dev --no-commit
+   forge install superfluid-protocol-monorepo=https://github.com/superfluid-finance/protocol-monorepo --no-commit
    ```
 
    Installs the `dev` branch of the Superfluid protocol from its GitHub repository.
@@ -39,7 +39,7 @@ Before diving into testing your Superfluid contracts with Foundry, make sure you
 4. **Installing OpenZeppelin Contracts**:
 
    ```bash
-   forge install https://github.com/OpenZeppelin/openzeppelin-contracts@v4.9.3 --no-commit
+   forge install https://github.com/OpenZeppelin/openzeppelin-contracts@v4.9.6 --no-commit
    ```
 
    Installs the necessary (4.9.X) of the OpenZeppelin contracts, which are widely used for secure smart contract development.
@@ -117,7 +117,7 @@ contract DistributionContract {
     function updateMemberUnits(address memberAddress, uint128 newUnits) external {
 
         // Update member units
-        daix.updateMemberUnits(pool, memberAddress, newUnits);
+        pool.updateMemberUnits(memberAddress, newUnits);
 
     }
 

--- a/docs/protocol/money-streaming/guides/acl-user-data.mdx
+++ b/docs/protocol/money-streaming/guides/acl-user-data.mdx
@@ -63,10 +63,10 @@ function setFlowPermissions(
 ) internal returns (bool)
 ```
 
-2. `createFlowFrom`: Create a flow as an operator on behalf of another account.
+2. `flowFrom`: Control a flow as an operator on behalf of another account.
 
 ```solidity
-function createFlowFrom(
+function flowFrom(
     ISuperToken token,
     address sender,
     address receiver,
@@ -95,17 +95,16 @@ User data in Superfluid allows developers to attach additional information to tr
 
 Many functions in the SuperTokenV1Library accept a `userData` parameter. This is typically a `bytes` type, allowing you to encode any data you want to include.
 
-Example of using user data when creating a flow:
+Example of using user data when controlling a flow:
 
 ```solidity
-function createFlowWithUserData(
+function flowFrom(
     ISuperToken token,
+    address sender,
     address receiver,
     int96 flowRate,
     bytes memory userData
-) internal {
-    token.createFlow(receiver, flowRate, userData);
-}
+) internal returns (bool)
 ```
 
 You can encode various types of data into the `userData` parameter. For example:
@@ -123,9 +122,8 @@ Here's a simple example demonstrating how one contract can grant permissions to 
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "@superfluid-finance/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol";
-import "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
-import "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperToken.sol";
+import { ISuperfluid, ISuperToken } from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
+import { SuperTokenV1Library } from "@superfluid-finance/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol";
 
 contract PermissionGranter {
     using SuperTokenV1Library for ISuperToken;
@@ -154,7 +152,7 @@ contract FlowCreator {
         address receiver,
         int96 flowRate
     ) external {
-        token.createFlowFrom(sender, receiver, flowRate);
+        token.flowFrom(sender, receiver, flowRate);
     }
 }
 ```

--- a/docs/protocol/money-streaming/guides/create-update-delete-flow.mdx
+++ b/docs/protocol/money-streaming/guides/create-update-delete-flow.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Create, Update, and Delete Flows
+# Control Flows
 
 This guide covers various methods for managing flows directly on the Superfluid protocol. It includes creating, updating, and deleting flows, **on chain, from another smart contracts**.
 This guide does NOT cover:
@@ -29,17 +29,45 @@ However, in Superfluid, a "Flow" is a more general term than a "Stream".
 A Stream is a non-zero flow, while a zero flow is not considered a Stream.
 :::
 
-## Create a flow
+## Set the flowrate
 
-To create a flow, you need to call `createFlow`by specifying the token, sender, receiver, and flow rate.
+### Function `flow`
+
+This function sets the specified flowrate between sender and receiver.
+
+```
+/**
+    * @dev Sets the given CFA flowrate between the caller and a given receiver.
+    * If there's no pre-existing flow and `flowRate` non-zero, a new flow is created.
+    * If there's an existing flow and `flowRate` non-zero, the flowRate of that flow is updated.
+    * If there's an existing flow and `flowRate` zero, the flow is deleted.
+    * If the existing and given flowRate are equal, no action is taken.
+    * On creation of a flow, a "buffer" amount is automatically detracted from the sender account's available balance.
+    * If the sender account is solvent when the flow is deleted, this buffer is redeemed to it.
+    * @param token Super token address
+    * @param receiver The receiver of the flow
+    * @param flowRate The wanted flowrate in wad/second. Only positive values are valid here.
+    * @return bool
+    */
+function flow(ISuperToken token, address receiver, int96 flowRate)
+    internal returns (bool)
+```
+
+:::note when not using the lib
+The CFAv1Forwarder contract has a function called `setFlowrate` which does the same.
+:::
+
+## CRUD methods
+
+If you want to be more explicit when changing the state of flows, you can use the following CRUD methods:
 
 ### Function: `createFlow`
 
-This function creates a flow without user data.
+To create a flow, you need to call `createFlow` by specifying the token, sender, receiver, and flow rate.
 
 ```solidity
 /**
- * @dev Create flow without userData
+ * @dev Create flow
  * @param token The token used in flow
  * @param receiver The receiver of the flow
  * @param flowRate The desired flowRate
@@ -48,24 +76,13 @@ function createFlow(ISuperToken token, address receiver, int96 flowRate)
     internal returns (bool)
 ```
 
-:::note About "setFlowrate" function
-The CFAv1Forwarder contract has a function called `setFlowrate` which is used to create or update flows.
-This function does not exist in the [SuperTokenV1Library](/docs/technical-reference/SuperTokenV1Library) for a reason.
-
-In short, the main contributors to the Superfluid Protocol believe that the best practice of building on-chain contracts is
-to not abstract away the creation and update of flows through a wrapper. The developer using the library should be aware of
-the difference between creating and updating flows, and should call the appropriate function accordingly.
-:::
-
-## Update a flow
+### Function: `updateFlow`
 
 For an existing flow, you can update the flow rate through the `updateFlow` function.
 
-### Function: `updateFlow`
-
 ```solidity
 /**
- * @dev Update flow without userData
+ * @dev Update flow
  * @param token The token used in flow
  * @param receiver The receiver of the flow
  * @param flowRate The desired flowRate
@@ -74,11 +91,9 @@ function updateFlow(ISuperToken token, address receiver, int96 flowRate)
     internal returns (bool)
 ```
 
-## Deleting a flow
+### Function: `deleteFlow`
 
 To delete an eisting, you need to call `deleteFlow` and  specify the token, sender, and receiver.
-
-### Function: `deleteFlow`
 
 ```solidity
 /**
@@ -99,10 +114,9 @@ No, you cannot update or delete a non-existent flow. If a flow does not exist, t
 For a full list of functions related to creating, updating, and deleting flows, refer to the [SuperTokenV1Library technical reference](/docs/technical-reference/SuperTokenV1Library).
 :::
 
-## Example: Creating, Updating, and Deleting Flows
+## Example: Control Flows
 
 For this example, we'll use the `FlowSender` contract described in the [Quickstart](/docs/protocol/quickstart.mdx) as our example to demonstrate how to write a contract with creates, updates, deletes and reads flow data.
-
 
 <div>
 <details>
@@ -110,35 +124,26 @@ For this example, we'll use the `FlowSender` contract described in the [Quicksta
 <p>
 
 ```solidity
-//SPDX-License-Identifier: Unlicensed
-pragma solidity ^0.8.14;
-
-import { ISuperfluid, ISuperToken } from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
-
-import { SuperTokenV1Library } from "@superfluid-finance/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol";
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-// For deployment on Mumbai Testnet
+import { ISuperfluid, ISuperToken } from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
+import { SuperTokenV1Library } from "@superfluid-finance/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol";
 
 interface IFakeDAI is IERC20 {
-
     function mint(address account, uint256 amount) external;
-
 }
 
 contract FlowSender {
-
     using SuperTokenV1Library for ISuperToken;
 
     mapping (address => bool) public accountList;
-
     ISuperToken public daix;
 
     // fDAIx address on Polygon Mumbai = 0x5D8B4C2554aeB7e86F387B4d6c00Ac33499Ed01f
     constructor(ISuperToken _daix) {
-
         daix = _daix;
-
     }
 
     /// @dev Mints 10,000 fDAI to this contract and wraps it all into fDAIx
@@ -155,41 +160,17 @@ contract FlowSender {
 
         // Wrap the fDAI into fDAIx
         daix.upgrade(10000e18);
-
     }
 
-    /// @dev creates a stream from this contract to desired receiver at desired rate
-    function createStream(int96 flowRate, address receiver) external {
-
-        // Create stream
-        daix.createFlow(receiver, flowRate);
-
+    /// @dev controls a stream with the given flowrate between this contract and the desired receiver
+    function setStream(address receiver, int96 flowRate) external {
+        daix.flow(receiver, flowRate);
     }
 
-    /// @dev updates a stream from this contract to desired receiver to desired rate
-    function updateStream(int96 flowRate, address receiver) external {
-
-        // Update stream
-        daix.updateFlow(receiver, flowRate);
-
-    }
-
-    /// @dev deletes a stream from this contract to desired receiver
-    function deleteStream(address receiver) external {
-
-        // Delete stream
-        daix.deleteFlow(address(this), receiver);
-
-    }
-
-    /// @dev get flow rate between this contract to certain receiver
-    function readFlowRate(address receiver) external view returns (int96 flowRate) {
-
-        // Get flow rate
+    /// @dev get flow rate between this contract and the given receiver
+    function getFlowRate(address receiver) external view returns (int96 flowRate) {
         return daix.getFlowRate(address(this), receiver);
-
     }
-
 }
 ```
 
@@ -200,10 +181,8 @@ contract FlowSender {
 This contract has a few functions:
 
 - **gainDaiX**: Mints and wraps fDAI into fDAIx (Superfluid's wrapped token).
-- **createStream**: Initiates a new money stream to a specified receiver.
-- **updateStream**: Updates an existing money stream's flow rate.
-- **deleteStream**: Terminates an existing money stream.
-- **readFlowRate**: Reads the current flow rate of a stream.
+- **setStream**: Controls a stream between the contract and a receiver
+- **getFlowRate**: Reads the current flow rate of a stream.
 
 :::tip About the `SuperTokenV1Library`
 As you can see, the `FlowSender` contract uses the [`SuperTokenV1Library`](/docs/technical-reference/SuperTokenV1Library) to interact with the Superfluid protocol.

--- a/docs/protocol/money-streaming/guides/testing.mdx
+++ b/docs/protocol/money-streaming/guides/testing.mdx
@@ -32,7 +32,7 @@ Before diving into testing your Superfluid contracts with Foundry, make sure you
 3. **Installing Superfluid Protocol Dependencies**:
 
    ```bash
-   forge install superfluid-protocol-monorepo=https://github.com/superfluid-finance/protocol-monorepo@dev --no-commit
+   forge install superfluid-protocol-monorepo=https://github.com/superfluid-finance/protocol-monorepo --no-commit
    ```
 
    Installs the `dev` branch of the Superfluid protocol from its GitHub repository.
@@ -40,7 +40,7 @@ Before diving into testing your Superfluid contracts with Foundry, make sure you
 4. **Installing OpenZeppelin Contracts**:
 
    ```bash
-   forge install https://github.com/OpenZeppelin/openzeppelin-contracts@v4.9.3 --no-commit
+   forge install https://github.com/OpenZeppelin/openzeppelin-contracts@v4.9.6 --no-commit
    ```
 
    Installs the necessary (4.9.X) of the OpenZeppelin contracts, which are widely used for secure smart contract development.

--- a/docs/protocol/quickstart.mdx
+++ b/docs/protocol/quickstart.mdx
@@ -59,35 +59,26 @@ If you are new to blockchain development, you may not be familiar with the term 
 <p>
 
 ```solidity
-//SPDX-License-Identifier: Unlicensed
-pragma solidity ^0.8.14;
-
-import { ISuperfluid, ISuperToken } from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
-
-import { SuperTokenV1Library } from "@superfluid-finance/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol";
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-// For deployment on Mumbai Testnet
+import { ISuperfluid, ISuperToken } from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
+import { SuperTokenV1Library } from "@superfluid-finance/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol";
 
 interface IFakeDAI is IERC20 {
-
     function mint(address account, uint256 amount) external;
-
 }
 
 contract FlowSender {
-
     using SuperTokenV1Library for ISuperToken;
-    
-    mapping (address => bool) public accountList;
 
+    mapping (address => bool) public accountList;
     ISuperToken public daix;
 
     // fDAIx address on Polygon Mumbai = 0x5D8B4C2554aeB7e86F387B4d6c00Ac33499Ed01f
     constructor(ISuperToken _daix) {
-
         daix = _daix;
-
     }
 
     /// @dev Mints 10,000 fDAI to this contract and wraps it all into fDAIx
@@ -95,7 +86,7 @@ contract FlowSender {
 
         // Get address of fDAI by getting underlying token address from DAIx token
         IFakeDAI fdai = IFakeDAI( daix.getUnderlyingToken() );
-        
+
         // Mint 10,000 fDAI
         fdai.mint(address(this), 10000e18);
 
@@ -104,41 +95,17 @@ contract FlowSender {
 
         // Wrap the fDAI into fDAIx
         daix.upgrade(10000e18);
-
     }
 
-    /// @dev creates a stream from this contract to desired receiver at desired rate
-    function createStream(int96 flowRate, address receiver) external {
-
-        // Create stream
-        daix.createFlow(receiver, flowRate);
-
+    /// @dev controls a stream with the given flowrate between this contract and the desired receiver
+    function setStream(address receiver, int96 flowRate) external {
+        daix.flow(receiver, flowRate);
     }
 
-    /// @dev updates a stream from this contract to desired receiver to desired rate
-    function updateStream(int96 flowRate, address receiver) external {
-
-        // Update stream
-        daix.updateFlow(receiver, flowRate);
-
-    }
-
-    /// @dev deletes a stream from this contract to desired receiver
-    function deleteStream(address receiver) external {
-
-        // Delete stream
-        daix.deleteFlow(address(this), receiver);
-
-    }
-
-    /// @dev get flow rate between this contract to certain receiver
-    function readFlowRate(address receiver) external view returns (int96 flowRate) {
-        
-        // Get flow rate
+    /// @dev get flow rate between this contract and the given receiver
+    function getFlowRate(address receiver) external view returns (int96 flowRate) {
         return daix.getFlowRate(address(this), receiver);
-
     }
-
 }
 ```
 
@@ -147,14 +114,12 @@ contract FlowSender {
 </div>
 
 - **gainDaiX**: Mints and wraps fDAI into fDAIx (Superfluid's wrapped token).
-- **createStream**: Initiates a new money stream to a specified receiver.
-- **updateStream**: Updates an existing money stream's flow rate.
-- **deleteStream**: Terminates an existing money stream.
-- **readFlowRate**: Reads the current flow rate of a stream.
+- **setStream**: Controls a stream between the contract and a receiver
+- **getFlowRate**: Reads the current flow rate of a stream.
 
 ## Environment Setup and Deployment
 
-Deploy the `FlowSender` contract to a testnet like Mumbai using your preferred development environment.
+Deploy the `FlowSender` contract to a testnet using your preferred development environment.
 
 <Tabs>
   <TabItem value="remix" label="Remix IDE" default>
@@ -173,6 +138,18 @@ Deploy the `FlowSender` contract to a testnet like Mumbai using your preferred d
 For more information, check out the [Remix IDE documentation](https://remix-ide.readthedocs.io/en/latest/).
 
   </TabItem>
+  <TabItem value="foundry" label="Foundry">
+
+### Using Foundry
+
+1. **Set Up Foundry**: Initialize a new Foundry project with `forge init`.
+2. **Place Contract**: Add the `FlowSender` contract to your `src` directory.
+3. **Write Deployment Script**: Create a deployment script in the `script` directory.
+4. **Compile and Deploy**: Use `forge build` to compile and `forge deploy --network mumbai` to deploy.
+
+Learn more about Foundry at the [Foundry Book](https://book.getfoundry.sh).
+
+  </TabItem>
   <TabItem value="hardhat" label="Hardhat">
 
 ### Using Hardhat
@@ -186,24 +163,11 @@ For more information, check out the [Remix IDE documentation](https://remix-ide.
 Explore more about Hardhat in the [Hardhat documentation](https://hardhat.org/getting-started/).
 
   </TabItem>
-  <TabItem value="foundry" label="Foundry">
-
-### Using Foundry
-
-1. **Set Up Foundry**: Initialize a new Foundry project with `forge init`.
-2. **Place Contract**: Add the `FlowSender` contract to your `src` directory.
-3. **Write Deployment Script**: Create a deployment script in the `script` directory.
-4. **Compile and Deploy**: Use `forge build` to compile and `forge deploy --network mumbai` to deploy.
-
-Learn more about Foundry at the [Foundry Book](https://book.getfoundry.sh).
-
-  </TabItem>
 </Tabs>
 
 :::info *What is the token address?*
-When deploying the contract, you will need to provide the address of the fDAIx token on the testnet you are using. For example, on Mumbai Testnet, the address of fDAIx is `0x5D8B4C2554aeB7e86F387B4d6c00Ac33499Ed01f`.
-
-For other testnets, make sure to check out the [Superfluid Explorer](https://Explorer.superfluid.finance/goerli/supertokens).
+When deploying the contract, you will need to provide the address of the fDAIx token on the testnet you are using.
+You can find those addresses in the [Superfluid Explorer](https://explorer.superfluid.finance/goerli/supertokens).
 :::
 
 ## Interacting with the Contract


### PR DESCRIPTION
adjust to updated SuperTokenV1Library:
- distributeToPool() is now distribute()
- use flow() by default instead of CRUD methods
- token.updateMemberUnits -> pool.updateMemberUnits