### PR TITLE
fix: Point GitHub links at superfluid-org instead of superfluid-finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To set up your fork for contributing, you can use the following commands or modi
 
 ```console
 cd docs-v2
-git remote add upstream https://github.com/superfluid-finance/docs-v2.git
+git remote add upstream https://github.com/superfluid-org/docs-v2.git
 git fetch upstream
 git pull --rebase upstream main
 git checkout -b "feature/my-awesome-docs-update"

--- a/docs/concepts/advanced-topics/super-apps.mdx
+++ b/docs/concepts/advanced-topics/super-apps.mdx
@@ -56,4 +56,4 @@ Super Apps open up a realm of possibilities, combining custom logic with the fun
 
 For further inspiration, explore the following examples of Super Apps:
 
-[Explore Super App Examples](https://github.com/superfluid-finance/super-examples)
+[Explore Super App Examples](https://github.com/superfluid-org/super-examples)

--- a/docs/protocol/advanced-topics/solvency/liquidations-and-toga.mdx
+++ b/docs/protocol/advanced-topics/solvency/liquidations-and-toga.mdx
@@ -59,7 +59,7 @@ Every time a stream is closed while Critical during the Plebs Period, the remain
 Every time a stream is closed while Insolvent, the PIC is slashed, and the Pirate is rewarded with the full buffer amount.
 
 The monopoly on rewards during the Patrician Period gives PICs an incentive to make sure streams are closed during that timeframe.\
-They can set up one or multiple redundant instances of the [superfluid-sentinel](https://github.com/superfluid-finance/superfluid-sentinel) (and/or other mechanisms for closing streams) to ensure this. Note that the PIC account is not needed (not in a _hot wallet_) for this operations as the rewards incurred during the patrician period will be added to the PIC stake regardless of transaction sender.
+They can set up one or multiple redundant instances of the [superfluid-sentinel](https://github.com/superfluid-org/superfluid-sentinel) (and/or other mechanisms for closing streams) to ensure this. Note that the PIC account is not needed (not in a _hot wallet_) for this operations as the rewards incurred during the patrician period will be added to the PIC stake regardless of transaction sender.
 
 Plebs act as a fallback in case PICs fail to do their job despite of the incentives.\
 The earlier in the Pleb Period a Pleb closes the stream, the more buffer there's left as a reward.

--- a/docs/protocol/advanced-topics/solvency/running-a-sentinnel.mdx
+++ b/docs/protocol/advanced-topics/solvency/running-a-sentinnel.mdx
@@ -22,10 +22,10 @@ In our section on [Liquidations & TOGA](./liquidations-and-toga.mdx), we describ
 
 ### Sentinel Repository
 
-If you want to start running a Sentinel today, you can clone [this repo](https://github.com/superfluid-finance/superfluid-sentinel) and customize your own `.env` file before starting the software. At minimum, you're going to need a reliable RPC URL, and a private key with native tokens to pay for gas when performing liquidations. Detailed instructions for running your Sentinel can be found in the repository's README and in the above video.
+If you want to start running a Sentinel today, you can clone [this repo](https://github.com/superfluid-org/superfluid-sentinel) and customize your own `.env` file before starting the software. At minimum, you're going to need a reliable RPC URL, and a private key with native tokens to pay for gas when performing liquidations. Detailed instructions for running your Sentinel can be found in the repository's README and in the above video.
 
 <div style={{ textAlign: 'center', margin: '20px' }}>
-<a href="https://github.com/superfluid-finance/superfluid-sentinel" target="_blank" rel="noopener noreferrer">
+<a href="https://github.com/superfluid-org/superfluid-sentinel" target="_blank" rel="noopener noreferrer">
     <img src="https://img.shields.io/badge/GitHub-View%20Repo-black?style=for-the-badge&logo=github" alt="GitHub" />
 </a>
 </div>

--- a/docs/protocol/advanced-topics/super-apps/callbacks.mdx
+++ b/docs/protocol/advanced-topics/super-apps/callbacks.mdx
@@ -70,7 +70,7 @@ If you're making a call to a Superfluid agreement inside of a Super App callback
 
 
 :::note
-Note that this is a highly technical section for those looking to understand lower level features of the protocol. If you're looking to create, update, and delete streams or work with the instant distribution agreement in your super app callbacks, you can refer to the [SuperTokenV1Library](https://github.com/superfluid-finance/super-examples/blob/main/projects/tradeable-cashflow/contracts/RedirectAll.sol#L223) to perform these operations in a single line of code.
+Note that this is a highly technical section for those looking to understand lower level features of the protocol. If you're looking to create, update, and delete streams or work with the instant distribution agreement in your super app callbacks, you can refer to the [SuperTokenV1Library](https://github.com/superfluid-org/super-examples/blob/main/projects/tradeable-cashflow/contracts/RedirectAll.sol#L223) to perform these operations in a single line of code.
 :::
 
 ### In Depth

--- a/docs/protocol/advanced-topics/super-apps/deploy-a-super-app.mdx
+++ b/docs/protocol/advanced-topics/super-apps/deploy-a-super-app.mdx
@@ -17,7 +17,7 @@ Super Apps are smart contracts registered with the Superfluid Protocol, allowing
     <p>*Super App Illustration*</p>
 </div>
 
-This guide provides a simple example of how to deploy a Super App using the [CFASuperAppBase](https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/apps/CFASuperAppBase.sol).
+This guide provides a simple example of how to deploy a Super App using the [CFASuperAppBase](https://github.com/superfluid-org/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/apps/CFASuperAppBase.sol).
 
 :::tip About this Guide
 This guide provides a basic example of deploying a Super App using the CFASuperAppBase contract. For more advanced Super App development, refer to the [Super Apps in Depth](/docs/protocol/advanced-topics/super-apps/understand-super-apps).
@@ -29,9 +29,9 @@ For most use cases, the CFASuperAppBase is sufficient. It simplifies the callbac
 
 ## CFASuperAppBase - Simplifying Super App Development
 
-### What is [CFASuperAppBase](https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/apps/CFASuperAppBase.sol)?
+### What is [CFASuperAppBase](https://github.com/superfluid-org/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/apps/CFASuperAppBase.sol)?
 
-[CFASuperAppBase](https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/apps/CFASuperAppBase.sol) is an inheritable base contract designed to streamline the development of Super Apps.
+[CFASuperAppBase](https://github.com/superfluid-org/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/apps/CFASuperAppBase.sol) is an inheritable base contract designed to streamline the development of Super Apps.
 It abstracts the complexities involved in writing callbacks and reduces redundancy.
 
 <div style={{ display: 'flex', justifyContent: 'center' }}>

--- a/docs/protocol/advanced-topics/super-apps/understand-super-apps.mdx
+++ b/docs/protocol/advanced-topics/super-apps/understand-super-apps.mdx
@@ -18,7 +18,7 @@ Super Apps are smart contracts registered with the Superfluid Protocol, allowing
     <p>*The Tradeable Cashflow NFT*</p>
 </div>
 
-Super Apps can execute custom logic in response to streaming-related actions. A great example is the [tradeable cashflow NFT contract](https://github.com/superfluid-finance/super-examples/tree/c784d239557d6fb5e56a2c8951ac4353256d611d/projects/tradeable-cashflow), which automatically opens a new stream from the NFT contract to the owner of the NFT upon receiving a stream.
+Super Apps can execute custom logic in response to streaming-related actions. A great example is the [tradeable cashflow NFT contract](https://github.com/superfluid-org/super-examples/tree/c784d239557d6fb5e56a2c8951ac4353256d611d/projects/tradeable-cashflow), which automatically opens a new stream from the NFT contract to the owner of the NFT upon receiving a stream.
 
 Callbacks in Super Apps are triggered by these actions:
 
@@ -49,7 +49,7 @@ _host.registerAppWithKey(configWord, registrationKey);
 
 The `APP_LEVEL_FINAL` flag ensures that the callbacks run in the first app in a chain of Super Apps. The `_NOOP` designations specify which callbacks are not used, avoiding unnecessary reverts.
 
-For mainnet deployments, pre-approval is required for registering Super Apps. Check out the [Super App White-listing Guide](https://github.com/superfluid-finance/protocol-monorepo/wiki/Super-App-White-listing-Guide) for more information.
+For mainnet deployments, pre-approval is required for registering Super Apps. Check out the [Super App White-listing Guide](https://github.com/superfluid-org/protocol-monorepo/wiki/Super-App-White-listing-Guide) for more information.
 
 ### Super App Stream Buffers
 

--- a/docs/protocol/contribute/bounty-program.mdx
+++ b/docs/protocol/contribute/bounty-program.mdx
@@ -35,7 +35,7 @@ A Superfluid team member will open a Discord thread for communication as you wor
 
 ## Upon Completion
 
-- Submit a pull request and tag the bounty issue you've completed in it ([Example Pull Request](https://github.com/superfluid-finance/protocol-monorepo/pull/717)).
+- Submit a pull request and tag the bounty issue you've completed in it ([Example Pull Request](https://github.com/superfluid-org/protocol-monorepo/pull/717)).
 - Once it's merged, fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSePPMtMcDndvgJvpkDMtY1BChkrXaqABO0SKA-4c-i2rbhZKA/viewform) and submit [this invoice](https://app.request.finance/create/3834fe3c2faaa829) to us.
     - In the Bounty KYC Form, for "Hackathon Name" put down the "Bounty".
     - In the Bounty KYC Form, for "Your Hack Name" put down the title of your bounty.

--- a/docs/protocol/contribute/bug-bounties.mdx
+++ b/docs/protocol/contribute/bug-bounties.mdx
@@ -28,13 +28,13 @@ For more details, please visit the [Immunefi Bug Bounty Program page](https://im
 
 Superfluid has been audited on multiple occasions, you can find these past audit reports here:
 
-For the audit reports, check out the [Superfluid GitHub repository](https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/ethereum-contracts/audits).
+For the audit reports, check out the [Superfluid GitHub repository](https://github.com/superfluid-org/protocol-monorepo/tree/dev/packages/ethereum-contracts/audits).
 
 ## General Security Tips For Superfluid Developers
 
 - We recommend what every good security expert would recommend: full test coverage, separation of concerns, and using automated tools like GitHub Actions or [Trail of Bits](https://blog.trailofbits.com/2018/03/23/use-our-suite-of-ethereum-security-tools/)' tools for fuzzing & static analysis
   - Guides like [this one from Consensys](https://consensys.github.io/smart-contract-best-practices/) can be helpful in understanding what to think about before deploying smart contracts to mainnet.
-  - If you're looking for inspiration on setting up your own GitHub Actions pipelines, you can find a breakdown of Superfluid's own GitHub Actions setup [here](https://github.com/superfluid-finance/protocol-monorepo/wiki/Superfluid-GitHub-Actions-Deep-Dive).
+  - If you're looking for inspiration on setting up your own GitHub Actions pipelines, you can find a breakdown of Superfluid's own GitHub Actions setup [here](https://github.com/superfluid-org/protocol-monorepo/wiki/Superfluid-GitHub-Actions-Deep-Dive).
 - Beyond this, we recommend that you continue to think about security & potential for loss of funds in the front end and off-chain components of your project (if you have them).
   - For example, we highly recommend you adopt some of the same UX practices that we do in the [Superfluid dashboard](https://app.superfluid.finance/) if you have a front end that allows people to create Superfluid streams.
   - I.e., we let the user know that letting their balance hit zero before they close their stream will [lead to a liquidation](/docs/protocol/advanced-topics/solvency/liquidations-and-toga).
@@ -46,5 +46,5 @@ For the audit reports, check out the [Superfluid GitHub repository](https://gith
 
 ### Custom Super Tokens
 
-- In general, we advise sticking to the existing Super Token interfaces seen [here](https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/ethereum-contracts/contracts/interfaces/tokens) unless you have a good reason not to.
+- In general, we advise sticking to the existing Super Token interfaces seen [here](https://github.com/superfluid-org/protocol-monorepo/tree/dev/packages/ethereum-contracts/contracts/interfaces/tokens) unless you have a good reason not to.
 - If you want to deviate from this, we strongly encourage you to reach out to the Superfluid developer team in the #dev-support channel in our [Discord](https://discord.superfluid.finance).

--- a/docs/protocol/distributions/guides/pools.mdx
+++ b/docs/protocol/distributions/guides/pools.mdx
@@ -14,7 +14,7 @@ The [`SuperTokenV1Library.sol`](/docs/technical-reference/SuperTokenV1Library) i
 :::
 
 :::warning About the General Distributions Agreement - GDA
-At times, we use "Distribution Pools" or the "General Distributions Agreement (GDA)" interchangeably due to "GDA" being the name of the implementation in our [codebase](https://github.com/superfluid-finance/protocol-monorepo). 
+At times, we use "Distribution Pools" or the "General Distributions Agreement (GDA)" interchangeably due to "GDA" being the name of the implementation in our [codebase](https://github.com/superfluid-org/protocol-monorepo). 
 :::
 
 ## What is a Pool?

--- a/docs/protocol/distributions/guides/testing.mdx
+++ b/docs/protocol/distributions/guides/testing.mdx
@@ -31,7 +31,7 @@ Before diving into testing your Superfluid contracts with Foundry, make sure you
 3. **Installing Superfluid Protocol Dependencies**:
 
    ```bash
-   forge install superfluid-protocol-monorepo=https://github.com/superfluid-finance/protocol-monorepo --no-commit
+   forge install superfluid-protocol-monorepo=https://github.com/superfluid-org/protocol-monorepo --no-commit
    ```
 
    Installs the `dev` branch of the Superfluid protocol from its GitHub repository.

--- a/docs/protocol/examples/example1.mdx
+++ b/docs/protocol/examples/example1.mdx
@@ -21,7 +21,7 @@ This example addresses the following Superfluid Protocol features:
 - [Super Apps](/docs/protocol/advanced-topics/super-apps/deploy-a-super-app)
 
 :::tip Check out the full codebase
-For the complete implementation of the DApp, including the smart contract and foundry test, refer to the [GitHub repository](https://github.com/superfluid-finance/ad-auction-example).
+For the complete implementation of the DApp, including the smart contract and foundry test, refer to the [GitHub repository](https://github.com/superfluid-org/ad-auction-example).
 :::
 
 ### The Problem
@@ -69,7 +69,7 @@ This guide is intended for blockchain developers and assumes familiarity with Et
 
 ## Smart Contract Implementation
 
-The [`AdSpotContract`](https://github.com/superfluid-finance/ad-auction-example/blob/master/src/AdSpotContract.sol) plays a crucial role in our DApp, integrating Superfluid's streaming capabilities for an innovative advertisement auction system. Let's dive into the key components and functionalities of this smart contract.
+The [`AdSpotContract`](https://github.com/superfluid-org/ad-auction-example/blob/master/src/AdSpotContract.sol) plays a crucial role in our DApp, integrating Superfluid's streaming capabilities for an innovative advertisement auction system. Let's dive into the key components and functionalities of this smart contract.
 
 ### Contract Overview
 
@@ -131,7 +131,7 @@ These functions are essential for users to interact with and understand the cont
 
 <Admonition type="info">
 
-For a complete code base and tests of the `AdSpotContract`, refer to the [full contract code](https://github.com/superfluid-finance/ad-auction-example/).
+For a complete code base and tests of the `AdSpotContract`, refer to the [full contract code](https://github.com/superfluid-org/ad-auction-example/).
 
 </Admonition>
 

--- a/docs/protocol/examples/example2.mdx
+++ b/docs/protocol/examples/example2.mdx
@@ -14,7 +14,7 @@ This guide explores the development of a staking platform, leveraging the capabi
 
 ## Repository
 
-The contract and associated tests can be found in the [SuperfluidStaking Repository](https://github.com/superfluid-finance/sf-example-staking).
+The contract and associated tests can be found in the [SuperfluidStaking Repository](https://github.com/superfluid-org/sf-example-staking).
 
 ## Contract Architecture
 
@@ -66,7 +66,7 @@ To set up the development environment and run the tests, follow these steps:
 2. **Clone the repository**
 
    ```bash
-   git clone https://github.com/superfluid-finance/sf-example-staking
+   git clone https://github.com/superfluid-org/sf-example-staking
    cd superfluid-staking
    ```
 

--- a/docs/protocol/money-streaming/guides/testing.mdx
+++ b/docs/protocol/money-streaming/guides/testing.mdx
@@ -32,7 +32,7 @@ Before diving into testing your Superfluid contracts with Foundry, make sure you
 3. **Installing Superfluid Protocol Dependencies**:
 
    ```bash
-   forge install superfluid-protocol-monorepo=https://github.com/superfluid-finance/protocol-monorepo --no-commit
+   forge install superfluid-protocol-monorepo=https://github.com/superfluid-org/protocol-monorepo --no-commit
    ```
 
    Installs the `dev` branch of the Superfluid protocol from its GitHub repository.

--- a/docs/protocol/quickstart.mdx
+++ b/docs/protocol/quickstart.mdx
@@ -28,14 +28,14 @@ You DO NOT need to follow this quickstart guide in order to create, update and d
 
 ## Prerequisites
 
-- The [Superfluid Simple Vesting Contract Repository](https://github.com/superfluid-finance/superfluid-boilerplate)
+- The [Superfluid Simple Vesting Contract Repository](https://github.com/superfluid-org/superfluid-quickstart)
 - A development environment *(Remix or Foundry)*
 - A testnet wallet (in case you want to deploy the contract to a testnet) *(e.g., MetaMask)*
 
 
 ## Contract Overview: SuperfluidBoilerplate
 
-In this guide we will describe the contract [`SuperfluidVesting.sol`](https://github.com/superfluid-finance/superfluid-quickstart/blob/master/src/SuperfluidVesting.sol):
+In this guide we will describe the contract [`SuperfluidVesting.sol`](https://github.com/superfluid-org/superfluid-quickstart/blob/master/src/SuperfluidVesting.sol):
 - This contract is designed to interact with the Superfluid protocol, specifically to deploy a [Super Token](/docs/protocol/super-tokens/overview) and use [Money Streaming](/docs/protocol/money-streaming/overview.mdx).
 - The contract enables the deployment of a Mock Super Token in the constructor.
 - This contract enables the creation, modification, and deletion of continuous money streams to the a recipient.
@@ -131,8 +131,8 @@ The contract has two main methods:
 ### Using Remix IDE
 
 1. **Create Files**: 
-   - Create `SuperfluidVesting.sol` and paste the main contract from the [repository's `/src` folder](https://github.com/superfluid-finance/superfluid-quickstart/tree/master/src)
-   - Create `PureSuperToken.sol` and paste the interface from the [repository's `/src` folder](https://github.com/superfluid-finance/superfluid-quickstart/tree/master/src)
+   - Create `SuperfluidVesting.sol` and paste the main contract from the [repository's `/src` folder](https://github.com/superfluid-org/superfluid-quickstart/tree/master/src)
+   - Create `PureSuperToken.sol` and paste the interface from the [repository's `/src` folder](https://github.com/superfluid-org/superfluid-quickstart/tree/master/src)
 2. **Compile**: Select compiler version 0.8.20 or higher
 3. **Deploy**: 
    - Select "Injected Provider - MetaMask"
@@ -145,7 +145,7 @@ The contract has two main methods:
 
 ### Using Foundry
 
-After cloning the [Superfluid Boilerplate Repository](https://github.com/superfluid-finance/superfluid-quickstart), you can test and deploy the contract with the following commands:
+After cloning the [Superfluid Boilerplate Repository](https://github.com/superfluid-org/superfluid-quickstart), you can test and deploy the contract with the following commands:
 
 1. **Install Dependencies**:
 ```bash

--- a/docs/protocol/super-tokens/guides/deploy-super-token/deploy-custom-super-token.mdx
+++ b/docs/protocol/super-tokens/guides/deploy-super-token/deploy-custom-super-token.mdx
@@ -27,7 +27,7 @@ Before we begin, make sure you have the following:
 First, let's clone the Custom Super Tokens repository:
 
 ```bash
-git clone https://github.com/superfluid-finance/custom-supertokens
+git clone https://github.com/superfluid-org/custom-supertokens
 cd custom-supertokens
 ```
 
@@ -187,4 +187,4 @@ These functions allow you to customize the behavior of your Super Token while ma
 
 By following this guide, you should now be able to deploy and initialize custom Super Tokens for the Superfluid protocol. Remember to thoroughly test your custom implementations and consider the security implications of any additional functionality you add to your tokens.
 
-For more information on Custom Super Tokens, check out the [Custom Super Token Wiki](https://github.com/superfluid-finance/protocol-monorepo/wiki/About-Custom-Super-Token) and the [Deploy a Custom Super Token Guide](https://docs.superfluid.finance/docs/protocol/super-tokens/guides/deploy-super-token/deploy-custom-super-token).
+For more information on Custom Super Tokens, check out the [Custom Super Token Wiki](https://github.com/superfluid-org/protocol-monorepo/wiki/About-Custom-Super-Token) and the [Deploy a Custom Super Token Guide](https://docs.superfluid.finance/docs/protocol/super-tokens/guides/deploy-super-token/deploy-custom-super-token).

--- a/docs/protocol/super-tokens/guides/deploy-super-token/deploy-pure-super-token.mdx
+++ b/docs/protocol/super-tokens/guides/deploy-super-token/deploy-pure-super-token.mdx
@@ -59,8 +59,8 @@ Deploying a Pure Super Token allows for custom non-Superfluid logic integration.
 
 ### Detailed Steps
 
-1. **Repository Setup**: Clone the [custom-supertokens repository](https://github.com/superfluid-finance/custom-supertokens#setup) and follow the setup instructions.
-2. **Logic Selection**: Choose from existing logic examples or develop your own based on [PureSuperToken.sol](https://github.com/superfluid-finance/custom-supertokens/blob/main/contracts/PureSuperToken.sol).
+1. **Repository Setup**: Clone the [custom-supertokens repository](https://github.com/superfluid-org/custom-supertokens#setup) and follow the setup instructions.
+2. **Logic Selection**: Choose from existing logic examples or develop your own based on [PureSuperToken.sol](https://github.com/superfluid-org/custom-supertokens/blob/main/contracts/PureSuperToken.sol).
 3. **Deployment**: Create a .env file, configure it for your network, and follow the repository's deployment steps.
 
 <Admonition type="note" title="Custom Logic Caution">

--- a/docs/protocol/super-tokens/guides/deploy-super-token/deploy-wrapped-super-token.mdx
+++ b/docs/protocol/super-tokens/guides/deploy-super-token/deploy-wrapped-super-token.mdx
@@ -28,7 +28,7 @@ Before you start, ensure you have:
 ---
 ## Super Tokens Factory Contract
 
-The [Super Token Factory contract](https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol) is used to create Super Tokens:
+The [Super Token Factory contract](https://github.com/superfluid-org/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol) is used to create Super Tokens:
 - It is permissionless and can be used by anyone to create Super Tokens.
 - It is deployed on all the networks where you can find the Superfluid Protocol.
 
@@ -61,11 +61,11 @@ You can deploy your own Wrapper Super Token using the Super Token Factory contra
 - **Symbol**: The symbol of the Super Token. We recommend using the same symbol as the underlying token suffixed with 'x' (eg. 'DAIx').
 
 :::tip What is Upgradability?
-If you look at the `CreateERC20Wrapper` method at the [Super Token Factory contract](https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol), you'll see a parameter called `Upgradability`.
+If you look at the `CreateERC20Wrapper` method at the [Super Token Factory contract](https://github.com/superfluid-org/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol), you'll see a parameter called `Upgradability`.
 
 This allows Superfluid Protocol Governance to upgrade the Super Token contract in the future and stay compatible with the latest features.
     - '0': Not Upgradable: The contract cannot be upgraded.
-    - '1': Semi-Upgradability: The contract can be upgraded by Superfluid Protocol Governance but only under certain [conditions](https://github.com/superfluid-finance/protocol-monorepo/wiki/About-Super-Token-Classification).
+    - '1': Semi-Upgradability: The contract can be upgraded by Superfluid Protocol Governance but only under certain [conditions](https://github.com/superfluid-org/protocol-monorepo/wiki/About-Super-Token-Classification).
     - '2': Fully Upgradable: The contract can be upgraded by Superfluid Protocol Governance without any restrictions.
 
 For the purpose of simplicity, we always recommend using '1'. This is why this parameter is not included in the interface below and is set to 1 by default.
@@ -112,7 +112,7 @@ Self-Governed Super Tokens give you the ability to control and update Super Toke
 
 <Admonition type="tip">
 
-For more information, see the [Self-Governed Super Token Wiki](https://github.com/superfluid-finance/protocol-monorepo/wiki/Self-Governed-Super-Token) or seek assistance on [Superfluid Discord](https://discord.superfluid.finance/).
+For more information, see the [Self-Governed Super Token Wiki](https://github.com/superfluid-org/protocol-monorepo/wiki/Self-Governed-Super-Token) or seek assistance on [Superfluid Discord](https://discord.superfluid.finance/).
 
 </Admonition>
 

--- a/docs/protocol/super-tokens/guides/using-library.mdx
+++ b/docs/protocol/super-tokens/guides/using-library.mdx
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Using the SuperTokenV1Library
 
-The [SuperTokenV1Library](https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol) is the primary interface for developers to interact with the Superfluid protocol
+The [SuperTokenV1Library](https://github.com/superfluid-org/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol) is the primary interface for developers to interact with the Superfluid protocol
 when building smart contracts on-chain.
 
 This comprehensive library provides all the necessary tools to work with the two main primitives of the Superfluid protocol:

--- a/docs/sdk/advanced-topics/batch-calls-macro.mdx
+++ b/docs/sdk/advanced-topics/batch-calls-macro.mdx
@@ -27,7 +27,7 @@ extends the capabilities of the Host by allowing a trusted forwarder to pass the
 
 Introducing a simple and secure way for builders to define their own macros without needing to be directly trusted by the Superfluid host contract.
 This approach simplifies on-chain logic for batch calls, reduces gas consumption and potentially ameliorates the front-end code, addressing atomicity issues.
-Today, Superfluid has a contract called [`MacroForwarder.sol`](https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/utils/MacroForwarder.sol)
+Today, Superfluid has a contract called [`MacroForwarder.sol`](https://github.com/superfluid-org/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/utils/MacroForwarder.sol)
  which is a trusted forwarder for user-defined macro interfaces.
 
 <div>

--- a/docs/sdk/distributions/subgraph.mdx
+++ b/docs/sdk/distributions/subgraph.mdx
@@ -154,7 +154,7 @@ You can have the full list of available subgraph endpoints in the [Subgraph Endp
 
 - **Subgraph Queries**: [Guide on Querying the Graph](https://thegraph.com/docs/en/developer/query-the-graph/)
 - **Deploy a Subgraph**: [Creating a Subgraph](https://thegraph.com/docs/en/developer/create-subgraph-hosted/)
-- **GraphQL Schema**: [Superfluid Schema](https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/subgraph/schema.graphql)
+- **GraphQL Schema**: [Superfluid Schema](https://github.com/superfluid-org/protocol-monorepo/blob/dev/packages/subgraph/schema.graphql)
 - **Our Subgraph Endpoints**: [Subgraph Endpoints](/docs/technical-reference/subgraph)
 
 

--- a/docs/sdk/examples/example1.mdx
+++ b/docs/sdk/examples/example1.mdx
@@ -8,7 +8,7 @@ This guide will walk you through creating a web application that enables
 streaming reward distributions using Superfluid's [Distribution Pools](/docs/protocol/distributions/overview) and Macro for [Batching Calls](/docs/sdk/advanced-topics/batch-calls).
 
 :::tip
-If you want to see the full example, you can check it out in the [GitHub Repository](https://github.com/superfluid-finance/rewards-macro-example).
+If you want to see the full example, you can check it out in the [GitHub Repository](https://github.com/superfluid-org/rewards-macro-example).
 :::
 
 ## Overview
@@ -63,9 +63,9 @@ To deploy a Distribution Pool, you can use the [GDAv1Forwarder](/docs/technical-
 
 [Macros](/docs/sdk/advanced-topics/batch-calls) allow us to batch multiple operations into a single transaction. In our case, we're using:
 - `MacroForwarder`: Contract that executes our macro
-- [`RewardsMacro`](https://github.com/superfluid-finance/rewards-macro-example/blob/main/contracts/RewardsMacro.sol): Our custom macro for setting up distributions
+- [`RewardsMacro`](https://github.com/superfluid-org/rewards-macro-example/blob/main/contracts/RewardsMacro.sol): Our custom macro for setting up distributions
 
-In our example, we deployed a [`RewardsMacro`](https://github.com/superfluid-finance/rewards-macro-example/blob/main/contracts/RewardsMacro.sol) contract on [OP Sepolia](https://optimism-sepolia.blockscout.com/address/0xA315e7EB0a278fac7B3a74DB895f5bf801EAb632?tab=contract) for the purposes of our example.
+In our example, we deployed a [`RewardsMacro`](https://github.com/superfluid-org/rewards-macro-example/blob/main/contracts/RewardsMacro.sol) contract on [OP Sepolia](https://optimism-sepolia.blockscout.com/address/0xA315e7EB0a278fac7B3a74DB895f5bf801EAb632?tab=contract) for the purposes of our example.
 
 ## Key Components
 

--- a/docs/sdk/money-streaming/subgraph.mdx
+++ b/docs/sdk/money-streaming/subgraph.mdx
@@ -155,7 +155,7 @@ You can have the full list of available subgraph endpoints in the [Subgraph Endp
 
 - **Subgraph Queries**: [Guide on Querying the Graph](https://thegraph.com/docs/en/developer/query-the-graph/)
 - **Deploy a Subgraph**: [Creating a Subgraph](https://thegraph.com/docs/en/developer/create-subgraph-hosted/)
-- **GraphQL Schema**: [Superfluid Schema](https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/subgraph/schema.graphql)
+- **GraphQL Schema**: [Superfluid Schema](https://github.com/superfluid-org/protocol-monorepo/blob/dev/packages/subgraph/schema.graphql)
 - **Our Subgraph Endpoints**: [Subgraph Endpoints](/docs/technical-reference/subgraph)
 
 ## Helpful Tips

--- a/docs/sdk/super-tokens/wrap-unwrap.mdx
+++ b/docs/sdk/super-tokens/wrap-unwrap.mdx
@@ -17,7 +17,7 @@ If you need to deploy a Wrapped Super Token, you can follow our guide on [Deploy
 
 Super Tokens are an enhanced version of ERC20 tokens, typically built on top of existing ERC20 tokens. This means that to use a Super Token, you often need to "wrap" an ERC20 token into its Super Token equivalent, and vice versa when you want to convert back to the original ERC20.
 
-To find out the address of the underlying ERC20 token for a Super Token, you can use the `getUnderlyingToken` view function provided by the [Super Token interface contract](https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperToken.sol).
+To find out the address of the underlying ERC20 token for a Super Token, you can use the `getUnderlyingToken` view function provided by the [Super Token interface contract](https://github.com/superfluid-org/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperToken.sol).
 
 :::tip Super Token Interface
 You can find the complete Super Token interface in our [ISuperToken Technical Reference](/docs/technical-reference/ISuperToken).

--- a/docs/technical-reference/Architecture.mdx
+++ b/docs/technical-reference/Architecture.mdx
@@ -92,6 +92,6 @@ This is an NFT contract where tokens represent membership within a pool, grantin
 
 The technical details and contract interactions are further documented in the codebase. Refer to the following for an in-depth understanding:
 
-- [Superfluid Framework Deployment Steps](https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeploymentSteps.sol).
-- [Superfluid Protocol Monorepo Wiki](https://github.com/superfluid-finance/protocol-monorepo/wiki).
+- [Superfluid Framework Deployment Steps](https://github.com/superfluid-org/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeploymentSteps.sol).
+- [Superfluid Protocol Monorepo Wiki](https://github.com/superfluid-org/protocol-monorepo/wiki).
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -105,7 +105,7 @@ const config: Config = {
           label: "Explorer",
         },
         {
-          href: "https://github.com/superfluid-finance",
+          href: "https://github.com/superfluid-org",
           position: "right",
           label: "GitHub",
         },
@@ -164,7 +164,7 @@ const config: Config = {
           items: [
             {
               label: "GitHub",
-              href: "https://github.com/superfluid-finance",
+              href: "https://github.com/superfluid-org",
             },
             {
               label: "Discord",

--- a/vercel.json
+++ b/vercel.json
@@ -33,7 +33,7 @@
     { "source": "/superfluid/resources/security-and-bug-bounties", "destination": "/docs/protocol/contribute/bug-bounties", "permanent": true },
     { "source": "/superfluid/resources/token-dashboard-submission", "destination": "/docs/protocol/contribute/submit-token-dashboard", "permanent": true },
     { "source": "/superfluid/resources/learn-about-ethereum", "destination": "https://ethereum.org/developers"},
-    { "source": "/superfluid/resources/code-of-conduct", "destination": "https://github.com/superfluid-finance/protocol-monorepo?tab=coc-ov-file"},
+    { "source": "/superfluid/resources/code-of-conduct", "destination": "https://github.com/superfluid-org/protocol-monorepo?tab=coc-ov-file"},
     { "source": "/superfluid/docs/subgraph", "destination": "/docs/sdk/money-streaming/subgraph", "permanent": true },
     { "source": "/superfluid/protocol-developers(.*)", "destination": "/docs/protocol/quickstart"},
     { "source": "/superfluid/developers/interactive-tutorials/money-streaming-1", "destination": "/docs/protocol/money-streaming/guides/money-streaming-with-super-tokens/interact-off-chain", "permanent": true },


### PR DESCRIPTION
## Why

A user reported that the GitHub link on docs.superfluid.org points to `github.com/superfluid-finance` instead of `github.com/superfluid-org`. That's the navbar and footer GitHub icons (`docusaurus.config.ts`), but the same stale org appears throughout the docs.

Old URLs still redirect, so nothing was broken — just wrong.

## What

27 files, all `github.com/superfluid-finance` → `github.com/superfluid-org`, with three deliberate exceptions:

**1. `superfluid-boilerplate` was renamed, not just moved.** A blind rewrite would have produced a dead link:

| URL | Status |
|---|---|
| `superfluid-finance/superfluid-boilerplate` | 200 (redirects to `superfluid-org/superfluid-quickstart`) |
| `superfluid-org/superfluid-boilerplate` | **404** |

So `docs/protocol/quickstart.mdx` now points at `superfluid-org/superfluid-quickstart`.

**2. Left one URL on the old org** — the user-content asset in `docs/protocol/advanced-topics/super-apps/register.mdx` (`…/protocol-monorepo/assets/5479136/…`). The org segment there is a legacy identifier for a content-addressed asset, not a navigable path.

**3. Three pre-existing dead links** got the org rewrite but no content fix — they 404 under *both* orgs, so this PR neither causes nor fixes the rot. Worth a follow-up:

- `protocol-monorepo/…/utils/MacroForwarder.sol` — gone; repo now has `BlindMacroForwarder.sol` / `ClearMacroForwarderV1.sol`
- `protocol-monorepo/…/utils/SuperfluidFrameworkDeploymentSteps.sol` — now `…DeploymentSteps.t.sol`
- `custom-supertokens/blob/main/contracts/PureSuperToken.sol` — repo no longer has a `contracts/` dir

## Verification

Every rewritten URL was resolved with `curl`. All return 200 except the three known-dead ones above.

## Out of scope

The site still self-identifies as `docs.superfluid.finance` (`docusaurus.config.ts` `url:`), and there are many other `*.superfluid.finance` links (Explorer, blog, terms). That's a *domain* rename, distinct from this *GitHub org* rename — worth raising separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)