### PR TITLE
docs: link Graph Network subgraphs

### DIFF
--- a/docs/technical-reference/subgraph.mdx
+++ b/docs/technical-reference/subgraph.mdx
@@ -39,7 +39,20 @@ Below is a table of the available networks along with their details:
 | Scroll | scroll-mainnet | No | 534352 | https://subgraph-endpoints.superfluid.dev/scroll-mainnet/protocol-v1 |
 | Degen Chain | degenchain | No | 666666666 | https://subgraph-endpoints.superfluid.dev/degenchain/protocol-v1 |
 
+## The Graph Network
 
+The Protocol V1 subgraphs below are also published on The Graph Network. Their subgraph IDs remain stable across version updates.
 
-
+| Network Name | Subgraph ID |
+| --- | --- |
+| Gnosis Chain | [`CFe2JWsPy9eiT9B49m2E2gwxdCzWdm5kfYHRXi5VseXV`](https://thegraph.com/explorer/subgraphs/CFe2JWsPy9eiT9B49m2E2gwxdCzWdm5kfYHRXi5VseXV) |
+| Polygon | [`CvVf1MiypnZhwWZjbxMH9A8nR2qdcfTozC5DQ1cw4X9n`](https://thegraph.com/explorer/subgraphs/CvVf1MiypnZhwWZjbxMH9A8nR2qdcfTozC5DQ1cw4X9n) |
+| Optimism | [`48YRvi7PHbX4RJChq4nF8DpmJGZxcvUgwfdf8QoHBXxT`](https://thegraph.com/explorer/subgraphs/48YRvi7PHbX4RJChq4nF8DpmJGZxcvUgwfdf8QoHBXxT) |
+| Arbitrum One | [`7hoLgMuj3LcWkUfH5iNWqVn69rmVbk4mrdgx1FX3sa3M`](https://thegraph.com/explorer/subgraphs/7hoLgMuj3LcWkUfH5iNWqVn69rmVbk4mrdgx1FX3sa3M) |
+| Avalanche C | [`DFCYT7rtQtSh4gWnTKLV5M4WE5rfeP8XRVFov6zAP2Ee`](https://thegraph.com/explorer/subgraphs/DFCYT7rtQtSh4gWnTKLV5M4WE5rfeP8XRVFov6zAP2Ee) |
+| BNB Smart Chain | [`DHzZqkcybd9QorWd9aYvwUPv29PRiy6gJ2qrL3o7GpJb`](https://thegraph.com/explorer/subgraphs/DHzZqkcybd9QorWd9aYvwUPv29PRiy6gJ2qrL3o7GpJb) |
+| Ethereum | [`3ALqHuNpxGPi1ecKSzxBQrTiKznoVk9cQYemY2RR5pgd`](https://thegraph.com/explorer/subgraphs/3ALqHuNpxGPi1ecKSzxBQrTiKznoVk9cQYemY2RR5pgd) |
+| Celo | [`DnAAo2aA676F8DYkcUPrRTgpH4smc1Yo7D7BnzC3ErBh`](https://thegraph.com/explorer/subgraphs/DnAAo2aA676F8DYkcUPrRTgpH4smc1Yo7D7BnzC3ErBh) |
+| Base | [`5P6vRdU8BQUKMSc9v5sVDMczBRvURyK7hnrQCKf24PXW`](https://thegraph.com/explorer/subgraphs/5P6vRdU8BQUKMSc9v5sVDMczBRvURyK7hnrQCKf24PXW) |
+| Scroll | [`GYTFzsXxACg5X3sCuE6qtGy1SZFZ9nwLGqf84nVzGkPU`](https://thegraph.com/explorer/subgraphs/GYTFzsXxACg5X3sCuE6qtGy1SZFZ9nwLGqf84nVzGkPU) |
 


### PR DESCRIPTION
The subgraph endpoints page currently only lists the hosted URLs. This adds the corresponding mainnet Protocol V1 listings on The Graph Network, using stable subgraph IDs rather than release-specific deployment IDs.

Built locally with `npm ci && npm run build`.